### PR TITLE
Add step counter sensor with sensorfw backend.

### DIFF
--- a/src/imports/sensors/qmlstepcountersensor.cpp
+++ b/src/imports/sensors/qmlstepcountersensor.cpp
@@ -1,0 +1,130 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtSensors module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "qmlstepcountersensor.h"
+
+/*!
+    \qmltype StepCounterSensor
+    \instantiates QmlStepCounterSensor
+    \ingroup qml-sensors_type
+    \inqmlmodule QtSensors
+    \since QtSensors 5.0
+    \inherits Sensor
+    \brief The StepCounterSensor element reports on the user's steps since boot.
+
+    The StepCounterSensor element reports on the user's steps since boot.
+
+    This element wraps the QStepCounterSensor class. Please see the documentation for
+    QStepCounterSensor for details.
+
+    \sa StepCounterReading
+*/
+
+QmlStepCounterSensor::QmlStepCounterSensor(QObject *parent)
+    : QmlSensor(parent)
+    , m_sensor(new QStepCounterSensor(this))
+{
+}
+
+QmlStepCounterSensor::~QmlStepCounterSensor()
+{
+}
+
+QmlSensorReading *QmlStepCounterSensor::createReading() const
+{
+    return new QmlStepCounterSensorReading(m_sensor);
+}
+
+QSensor *QmlStepCounterSensor::sensor() const
+{
+    return m_sensor;
+}
+
+/*!
+    \qmltype StepCounterReading
+    \instantiates QmlStepCounterSensorReading
+    \ingroup qml-sensors_reading
+    \inqmlmodule QtSensors
+    \since QtSensors 5.0
+    \inherits SensorReading
+    \brief The StepCounterReading element holds the most recent StepCounterSensor reading.
+
+    The StepCounterReading element holds the most recent StepCounterSensor reading.
+
+    This element wraps the QStepCounterReading class. Please see the documentation for
+    QStepCounterReading for details.
+
+    This element cannot be directly created.
+*/
+
+QmlStepCounterSensorReading::QmlStepCounterSensorReading(QStepCounterSensor *sensor)
+    : QmlSensorReading(sensor)
+    , m_sensor(sensor)
+{
+}
+
+QmlStepCounterSensorReading::~QmlStepCounterSensorReading()
+{
+}
+
+/*!
+    \qmlproperty qreal StepCounterReading::steps
+    This property holds the number of steps since boot.
+
+    Please see QStepCounterReading::steps for information about this property.
+*/
+
+int QmlStepCounterSensorReading::steps() const
+{
+    return m_steps;
+}
+
+QSensorReading *QmlStepCounterSensorReading::reading() const
+{
+    return m_sensor->reading();
+}
+
+void QmlStepCounterSensorReading::readingUpdate()
+{
+    int steps = m_sensor->reading()->steps();
+    if (m_steps != steps) {
+        m_steps = steps;
+        Q_EMIT stepsChanged();
+    }
+}

--- a/src/imports/sensors/qmlstepcountersensor.h
+++ b/src/imports/sensors/qmlstepcountersensor.h
@@ -1,0 +1,84 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtSensors module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QMLSTEPCOUNTERSENSOR_H
+#define QMLSTEPCOUNTERSENSOR_H
+
+#include "qmlsensor.h"
+#include <QtSensors/QStepCounterSensor>
+
+QT_BEGIN_NAMESPACE
+
+class QStepCounterSensor;
+
+class QmlStepCounterSensor : public QmlSensor
+{
+    Q_OBJECT
+public:
+    explicit QmlStepCounterSensor(QObject *parent = 0);
+    ~QmlStepCounterSensor();
+
+private:
+    QSensor *sensor() const override;
+    QStepCounterSensor *m_sensor;
+    QmlSensorReading *createReading() const override;
+};
+
+class QmlStepCounterSensorReading : public QmlSensorReading
+{
+    Q_OBJECT
+    Q_PROPERTY(int steps READ steps NOTIFY stepsChanged)
+public:
+    explicit QmlStepCounterSensorReading(QStepCounterSensor *sensor);
+    ~QmlStepCounterSensorReading();
+
+    int steps() const;
+
+Q_SIGNALS:
+    void stepsChanged();
+
+private:
+    QSensorReading *reading() const override;
+    void readingUpdate() override;
+    QStepCounterSensor *m_sensor;
+    int m_steps;
+};
+
+QT_END_NAMESPACE
+#endif

--- a/src/imports/sensors/sensors.cpp
+++ b/src/imports/sensors/sensors.cpp
@@ -57,6 +57,7 @@
 #include <QtSensors/qtiltsensor.h>
 #include <QtSensors/qlidsensor.h>
 #include <QtSensors/qhrmsensor.h>
+#include <QtSensors/qstepcountersensor.h>
 
 #include "qmlsensorglobal.h"
 #include "qmlsensor.h"
@@ -79,6 +80,7 @@
 #include "qmlsensorgesture.h"
 #include "qmllidsensor.h"
 #include "qmlhrmsensor.h"
+#include "qmlstepcountersensor.h"
 
 static void initResources()
 {
@@ -165,6 +167,8 @@ public:
         qmlRegisterUncreatableType<QmlHolsterReading           >(package, major, minor, "HolsterReading",       QLatin1String("Cannot create HolsterReading"));
         qmlRegisterType           <QmlHrmSensor                >(package, major, minor, "HrmSensor");
         qmlRegisterUncreatableType<QmlHrmSensorReading         >(package, major, minor, "HrmReading",          QLatin1String("Cannot create HrmReading"));
+        qmlRegisterType           <QmlStepCounterSensor        >(package, major, minor, "StepCounterSensor");
+        qmlRegisterUncreatableType<QmlStepCounterSensorReading>(package, major, minor, "StepCounterReading",    QLatin1String("Cannot create StepCounterReading"));
         qmlRegisterType           <QmlIRProximitySensor        >(package, major, minor, "IRProximitySensor");
         qmlRegisterUncreatableType<QmlIRProximitySensorReading >(package, major, minor, "IRProximityReading",   QLatin1String("Cannot create IRProximityReading"));
         qmlRegisterType           <QmlLightSensor              >(package, major, minor, "LightSensor");

--- a/src/imports/sensors/sensors.pro
+++ b/src/imports/sensors/sensors.pro
@@ -24,7 +24,8 @@ HEADERS += \
     qmlsensorgesture.h \
     qmlhumiditysensor.h \
     qmllidsensor.h \
-    qmlhrmsensor.h
+    qmlhrmsensor.h \
+    qmlstepcountersensor.h
 
 SOURCES += sensors.cpp \
     qmlsensor.cpp \
@@ -50,7 +51,8 @@ SOURCES += sensors.cpp \
     qmlsensorgesture.cpp \
     qmlhumiditysensor.cpp \
     qmllidsensor.cpp \
-    qmlhrmsensor.cpp
+    qmlhrmsensor.cpp \
+    qmlstepcountersensor.cpp
 
 load(qml_plugin)
 

--- a/src/plugins/sensors/sensorfw/Sensors.conf
+++ b/src/plugins/sensors/sensorfw/Sensors.conf
@@ -12,3 +12,4 @@ QIRProximitySensor=sensorfw.irproximitysensor
 QGyroscope=sensorfw.gyroscope
 QLidSensor=sensorfw.lidsensor
 QHrmSensor=sensorfw.hrmsensor
+QStepCounterSensor=sensorfw.stepcountersensor

--- a/src/plugins/sensors/sensorfw/main.cpp
+++ b/src/plugins/sensors/sensorfw/main.cpp
@@ -50,6 +50,7 @@
 #include "sensorfwlightsensor.h"
 #include "sensorfwlidsensor.h"
 #include "sensorfwhrmsensor.h"
+#include "sensorfwstepcountersensor.h"
 
 #include <QtSensors/qsensorplugin.h>
 #include <QtSensors/qsensorbackend.h>
@@ -107,6 +108,8 @@ public:
             return new SensorfwIrProximitySensor(sensor);
         if (sensor->identifier() == SensorfwHrmSensor::id)
             return new SensorfwHrmSensor(sensor);
+        if (sensor->identifier() == SensorfwStepCounterSensor::id)
+            return new SensorfwStepCounterSensor(sensor);
         return 0;
     }
 };

--- a/src/plugins/sensors/sensorfw/sensorfw.pri
+++ b/src/plugins/sensors/sensorfw/sensorfw.pri
@@ -11,7 +11,8 @@ HEADERS += sensorfwsensorbase.h \
     sensorfwlightsensor.h  \
     sensorfwirproximitysensor.h \
     sensorfwlidsensor.h \
-    sensorfwhrmsensor.h
+    sensorfwhrmsensor.h \
+    sensorfwstepcountersensor.h
 
 SOURCES += sensorfwsensorbase.cpp \
     sensorfwaccelerometer.cpp \
@@ -27,4 +28,5 @@ SOURCES += sensorfwsensorbase.cpp \
     sensorfwlightsensor.cpp \
     sensorfwlidsensor.cpp \
     sensorfwhrmsensor.cpp \
+    sensorfwstepcountersensor.cpp \
     main.cpp

--- a/src/plugins/sensors/sensorfw/sensorfwstepcountersensor.cpp
+++ b/src/plugins/sensors/sensorfw/sensorfwstepcountersensor.cpp
@@ -1,0 +1,83 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtSensors module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "sensorfwstepcountersensor.h"
+
+char const * const SensorfwStepCounterSensor::id("sensorfw.stepcountersensor");
+
+SensorfwStepCounterSensor::SensorfwStepCounterSensor(QSensor *sensor)
+    : SensorfwSensorBase(sensor)
+    , m_initDone(false)
+{
+    init();
+    setReading<QStepCounterReading>(&m_reading);
+    m_sensor = (QStepCounterSensor *)sensor;
+}
+
+void SensorfwStepCounterSensor::slotDataAvailable(const Unsigned& data)
+{
+    m_reading.setSteps(data.UnsignedData().value_);
+    m_reading.setTimestamp(data.UnsignedData().timestamp_);
+    newReadingAvailable();
+}
+
+bool SensorfwStepCounterSensor::doConnect()
+{
+    Q_ASSERT(m_sensorInterface);
+    return QObject::connect(m_sensorInterface, SIGNAL(StepCounterChanged(Unsigned)),
+                            this, SLOT(slotDataAvailable(Unsigned)));
+}
+
+QString SensorfwStepCounterSensor::sensorName() const
+{
+    return "stepcountersensor";
+}
+
+void SensorfwStepCounterSensor::init()
+{
+    m_initDone = false;
+    initSensor<StepCounterSensorChannelInterface>(m_initDone);
+}
+
+void SensorfwStepCounterSensor::start()
+{
+    if (reinitIsNeeded)
+        init();
+    SensorfwSensorBase::start();
+}

--- a/src/plugins/sensors/sensorfw/sensorfwstepcountersensor.h
+++ b/src/plugins/sensors/sensorfw/sensorfwstepcountersensor.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtSensors module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+
+#ifndef SENSORFWSTEPCOUNTERSENSOR_H
+#define SENSORFWSTEPCOUNTERSENSOR_H
+
+#include "sensorfwsensorbase.h"
+#include <QtSensors/qstepcountersensor.h>
+
+#include <stepcountersensor_i.h>
+
+
+class SensorfwStepCounterSensor : public SensorfwSensorBase
+{
+    Q_OBJECT
+
+public:
+    static char const * const id;
+    SensorfwStepCounterSensor(QSensor *sensor);
+protected:
+    bool doConnect() override;
+    QString sensorName() const override;
+    void start() override;
+    virtual void init();
+private:
+    QStepCounterReading m_reading;
+    QStepCounterSensor *m_sensor;
+    bool m_initDone;
+private slots:
+    void slotDataAvailable(const Unsigned& data);
+};
+
+#endif

--- a/src/sensors/doc/src/compatmap.qdoc
+++ b/src/sensors/doc/src/compatmap.qdoc
@@ -152,6 +152,16 @@
     <td bgcolor="gray"></td>
     </tr>
     <tr>
+    <td nowrap="nowrap">Step Counter</td>
+    <td bgcolor="gray"></td>
+    <td bgcolor="gray"></td>
+    <td bgcolor="gray"></td>
+    <td bgcolor="gray"></td>
+    <td bgcolor="gray"></td>
+    <td bgcolor="green"></td>
+    <td bgcolor="gray"></td>
+    </tr>
+    <tr>
     <td nowrap="nowrap">Humidity Sensor</td>
     <td bgcolor="gray"></td>
     <td bgcolor="gray"></td>

--- a/src/sensors/qstepcountersensor.cpp
+++ b/src/sensors/qstepcountersensor.cpp
@@ -1,0 +1,156 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtSensors module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "qstepcountersensor.h"
+#include "qstepcountersensor_p.h"
+
+QT_BEGIN_NAMESPACE
+
+IMPLEMENT_READING(QStepCounterReading)
+
+/*!
+    \class QStepCounterReading
+    \ingroup sensors_reading
+    \inmodule QtSensors
+    \since 5.1
+
+    \brief The QStepCounterReading class represents one reading from the
+           step counter.
+
+    \section2 QHemReading Units
+    The step counter returns the user's steps since boot.
+*/
+
+/*!
+    \property QStepCounterReading::steps
+    \brief the steps since boot.
+
+    \sa {QStepCounterReading Units}
+*/
+
+int QStepCounterReading::steps() const
+{
+    return d->steps;
+}
+
+/*!
+    Sets the steps since boot to \a steps.
+*/
+void QStepCounterReading::setSteps(int steps)
+{
+    d->steps = steps;
+}
+
+// =====================================================================
+
+/*!
+    \class QStepCounterFilter
+    \ingroup sensors_filter
+    \inmodule QtSensors
+    \since 5.1
+
+    \brief The QStepCounterFilter class is a convenience wrapper around QSensorFilter.
+
+    The only difference is that the filter() method features a pointer to QStepCounterReading
+    instead of QSensorReading.
+*/
+
+/*!
+    \fn QStepCounterFilter::filter(QStepCounterReading *reading)
+
+    Called when \a reading changes. Returns false to prevent the reading from propagating.
+
+    \sa QSensorFilter::filter()
+*/
+
+bool QStepCounterFilter::filter(QSensorReading *reading)
+{
+    return filter(static_cast<QStepCounterReading*>(reading));
+}
+
+char const * const QStepCounterSensor::type("QStepCounterSensor");
+
+/*!
+    \class QStepCounterSensor
+    \ingroup sensors_type
+    \inmodule QtSensors
+    \since 5.1
+
+    \brief The QStepCounterSensor class is a convenience wrapper around QSensor.
+
+    The only behavioural difference is that this class sets the type properly.
+
+    This class also features a reading() function that returns a QStepCounterReading instead of a QSensorReading.
+
+    For details about how the sensor works, see \l QStepCounterReading.
+
+    \sa QStepCounterReading
+*/
+
+/*!
+    Construct the sensor as a child of \a parent.
+*/
+QStepCounterSensor::QStepCounterSensor(QObject *parent)
+    : QSensor(QStepCounterSensor::type, parent)
+{
+}
+
+/*!
+    Destroy the sensor. Stops the sensor if it has not already been stopped.
+*/
+QStepCounterSensor::~QStepCounterSensor()
+{
+}
+
+/*!
+    \fn QStepCounterSensor::reading() const
+
+    Returns the reading class for this sensor.
+
+    \sa QSensor::reading()
+*/
+
+QStepCounterReading *QStepCounterSensor::reading() const
+{
+    return static_cast<QStepCounterReading*>(QSensor::reading());
+}
+
+#include "moc_qstepcountersensor.cpp"
+QT_END_NAMESPACE
+

--- a/src/sensors/qstepcountersensor.h
+++ b/src/sensors/qstepcountersensor.h
@@ -1,0 +1,84 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtSensors module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QSTEPCOUNTERSENSOR_H
+#define QSTEPCOUNTERSENSOR_H
+
+#include <QtSensors/qsensor.h>
+
+QT_BEGIN_NAMESPACE
+
+class QStepCounterReadingPrivate;
+
+class Q_SENSORS_EXPORT QStepCounterReading : public QSensorReading
+{
+    Q_OBJECT
+    Q_PROPERTY(int steps READ steps)
+    DECLARE_READING(QStepCounterReading)
+public:
+    int steps() const;
+    void setSteps(int steps);
+};
+
+class Q_SENSORS_EXPORT QStepCounterFilter : public QSensorFilter
+{
+public:
+    virtual bool filter(QStepCounterReading *reading) = 0;
+private:
+    bool filter(QSensorReading *reading) override;
+};
+
+class Q_SENSORS_EXPORT QStepCounterSensor : public QSensor
+{
+    Q_OBJECT
+
+public:
+    explicit QStepCounterSensor(QObject *parent = Q_NULLPTR);
+    virtual ~QStepCounterSensor();
+    QStepCounterReading *reading() const;
+    static char const * const type;
+
+private:
+    Q_DISABLE_COPY(QStepCounterSensor)
+};
+
+QT_END_NAMESPACE
+
+#endif
+

--- a/src/sensors/qstepcountersensor_p.h
+++ b/src/sensors/qstepcountersensor_p.h
@@ -1,0 +1,72 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtSensors module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QSTEPCOUNTERSENSOR_P_H
+#define QSTEPCOUNTERSENSOR_P_H
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Qt API. It exists purely as an
+// implementation detail. This header file may change from version to
+// version without notice, or even be removed.
+//
+// We mean it.
+//
+
+#include "qsensor_p.h"
+
+QT_BEGIN_NAMESPACE
+
+class QStepCounterReadingPrivate : public QSensorReadingPrivate
+{
+public:
+    QStepCounterReadingPrivate()
+        : steps(0)
+    {
+    }
+
+    int steps;
+};
+
+QT_END_NAMESPACE
+
+#endif
+

--- a/src/sensors/sensors.pro
+++ b/src/sensors/sensors.pro
@@ -72,7 +72,8 @@ SENSORS=\
     qpressuresensor \
     qhumiditysensor \
     qlidsensor \
-    qhrmsensor
+    qhrmsensor \
+    qstepcountersensor
 
 for(s,SENSORS) {
     # Client API


### PR DESCRIPTION
This PR adds support for Qt QML apps to use the stepcounter/pedometer.

The code is pretty much a 1:1 copy from the HrmSensor, with the following changes:
- Remove status information
- Change HeartRate type to Unsigned
- Rename bpm to steps

I've created a demo app: https://github.com/MagneFire/asteroid-pedometer
One thing worth noting is that the stepcounter will only update when the app is active(screen is on, app is visible). The value reported when the app is started will always be 0 because the stepcounter sensor will only fire when a change in steps is detected.
(Ideally a deamon should be created that keeps the sensor active and does some other tracking: in other words fitness tracking daemon)

This partially implements https://github.com/AsteroidOS/asteroid/issues/134