### PR TITLE
Add sensorfw backend for pressure sensor

### DIFF
--- a/src/plugins/sensors/sensorfw/Sensors.conf
+++ b/src/plugins/sensors/sensorfw/Sensors.conf
@@ -13,3 +13,4 @@ QGyroscope=sensorfw.gyroscope
 QLidSensor=sensorfw.lidsensor
 QHrmSensor=sensorfw.hrmsensor
 QStepCounterSensor=sensorfw.stepcountersensor
+QPressureSensor=sensorfw.pressuresensor

--- a/src/plugins/sensors/sensorfw/main.cpp
+++ b/src/plugins/sensors/sensorfw/main.cpp
@@ -51,6 +51,7 @@
 #include "sensorfwlidsensor.h"
 #include "sensorfwhrmsensor.h"
 #include "sensorfwstepcountersensor.h"
+#include "sensorfwpressuresensor.h"
 
 #include <QtSensors/qsensorplugin.h>
 #include <QtSensors/qsensorbackend.h>
@@ -110,6 +111,8 @@ public:
             return new SensorfwHrmSensor(sensor);
         if (sensor->identifier() == SensorfwStepCounterSensor::id)
             return new SensorfwStepCounterSensor(sensor);
+        if (sensor->identifier() == SensorfwPressureSensor::id)
+            return new SensorfwPressureSensor(sensor);
         return 0;
     }
 };

--- a/src/plugins/sensors/sensorfw/sensorfw.pri
+++ b/src/plugins/sensors/sensorfw/sensorfw.pri
@@ -12,7 +12,8 @@ HEADERS += sensorfwsensorbase.h \
     sensorfwirproximitysensor.h \
     sensorfwlidsensor.h \
     sensorfwhrmsensor.h \
-    sensorfwstepcountersensor.h
+    sensorfwstepcountersensor.h \
+    sensorfwpressuresensor.h
 
 SOURCES += sensorfwsensorbase.cpp \
     sensorfwaccelerometer.cpp \
@@ -29,4 +30,5 @@ SOURCES += sensorfwsensorbase.cpp \
     sensorfwlidsensor.cpp \
     sensorfwhrmsensor.cpp \
     sensorfwstepcountersensor.cpp \
+    sensorfwpressuresensor.cpp \
     main.cpp

--- a/src/plugins/sensors/sensorfw/sensorfwpressuresensor.cpp
+++ b/src/plugins/sensors/sensorfw/sensorfwpressuresensor.cpp
@@ -1,0 +1,83 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtSensors module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "sensorfwpressuresensor.h"
+
+char const * const SensorfwPressureSensor::id("sensorfw.pressuresensor");
+
+SensorfwPressureSensor::SensorfwPressureSensor(QSensor *sensor)
+    : SensorfwSensorBase(sensor)
+    , m_initDone(false)
+{
+    init();
+    setReading<QPressureReading>(&m_reading);
+    m_sensor = (QPressureSensor *)sensor;
+}
+
+void SensorfwPressureSensor::slotDataAvailable(const Unsigned& data)
+{
+    m_reading.setPressure(data.UnsignedData().value_);
+    m_reading.setTimestamp(data.UnsignedData().timestamp_);
+    newReadingAvailable();
+}
+
+bool SensorfwPressureSensor::doConnect()
+{
+    Q_ASSERT(m_sensorInterface);
+    return QObject::connect(m_sensorInterface, SIGNAL(pressureChanged(Unsigned)),
+                            this, SLOT(slotDataAvailable(Unsigned)));
+}
+
+QString SensorfwPressureSensor::sensorName() const
+{
+    return "pressuresensor";
+}
+
+void SensorfwPressureSensor::init()
+{
+    m_initDone = false;
+    initSensor<PressureSensorChannelInterface>(m_initDone);
+}
+
+void SensorfwPressureSensor::start()
+{
+    if (reinitIsNeeded)
+        init();
+    SensorfwSensorBase::start();
+}

--- a/src/plugins/sensors/sensorfw/sensorfwpressuresensor.h
+++ b/src/plugins/sensors/sensorfw/sensorfwpressuresensor.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtSensors module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+
+#ifndef SENSORFWPRESSURESENSOR_H
+#define SENSORFWPRESSURESENSOR_H
+
+#include "sensorfwsensorbase.h"
+#include <QtSensors/qpressuresensor.h>
+
+#include <pressuresensor_i.h>
+
+
+class SensorfwPressureSensor : public SensorfwSensorBase
+{
+    Q_OBJECT
+
+public:
+    static char const * const id;
+    SensorfwPressureSensor(QSensor *sensor);
+protected:
+    bool doConnect() override;
+    QString sensorName() const override;
+    void start() override;
+    virtual void init();
+private:
+    QPressureReading m_reading;
+    QPressureSensor *m_sensor;
+    bool m_initDone;
+private slots:
+    void slotDataAvailable(const Unsigned& data);
+};
+
+#endif


### PR DESCRIPTION
this adds support for pressure sensor. Support exists already in sensorfw, so it was just a case of adding the plugin here. 
A setter method probably also needs to be added for calibrating the sensor, but I need to do a bit more reading to see how that works.

The barometer is also meant to act as an altimeter, and I'm not sure how that's meant to work. The android hal seems to expose only barometer, so I'm not sure where in the chain it gets converted into a virtual altimeter. 